### PR TITLE
[#1] updated gradoop version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,19 @@
+name: Java CI
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: 
+        os: [ubuntu-latest, macos-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>Gradoop Generators</name>
     <url>http://www.gradoop.org</url>
     <description>Data Generators for Gradoop</description>
-    <inceptionYear>2014 - 2018</inceptionYear>
+    <inceptionYear>2014 - 2019</inceptionYear>
 
     <organization>
         <name>University of Leipzig</name>
@@ -55,18 +55,23 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.maven.version>3.0.0</project.maven.version>
         <project.build.targetJdk>1.8</project.build.targetJdk>
+
         <dep.commons-io.version>2.4</dep.commons-io.version>
-        <dep.flink.version>1.5.0</dep.flink.version>
-        <dep.gradoop.version>0.4.2</dep.gradoop.version>
+
+        <dep.flink.version>1.7.0</dep.flink.version>
+        <dep.gradoop.version>0.5.1</dep.gradoop.version>
+
         <dep.guava.version>12.0.1</dep.guava.version>
+
         <dep.jettison.version>1.3.7</dep.jettison.version>
+
         <dep.junit.version>4.11</dep.junit.version>
-        <plugin.maven-compiler.version>3.5.1</plugin.maven-compiler.version>
-        <plugin.maven-checkstyle.version>2.16</plugin.maven-checkstyle.version>
-        <plugin.maven-findbugs.version>3.0.1</plugin.maven-findbugs.version>
-        <plugin.maven-jar.version>2.3.2</plugin.maven-jar.version>
+
+        <plugin.maven-compiler.version>3.8.0</plugin.maven-compiler.version>
+        <plugin.maven-checkstyle.version>3.0.0</plugin.maven-checkstyle.version>
+        <plugin.maven-jar.version>3.1.1</plugin.maven-jar.version>
         <plugin.maven-source.version>3.0.1</plugin.maven-source.version>
-        <plugin.maven-javadoc.version>3.0.1</plugin.maven-javadoc.version>
+        <plugin.maven-javadoc.version>3.1.1</plugin.maven-javadoc.version>
         <license.licenseName>apache_v2</license.licenseName>
     </properties>
 
@@ -80,57 +85,6 @@
                     <source>${project.build.targetJdk}</source>
                     <target>${project.build.targetJdk}</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>${plugin.maven-checkstyle.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.gradoop</groupId>
-                        <artifactId>gradoop-checkstyle</artifactId>
-                        <version>${dep.gradoop.version}</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <configLocation>gradoop/checkstyle.xml</configLocation>
-                    <headerLocation>gradoop/LICENSE.txt</headerLocation>
-                    <includeResources>false</includeResources>
-                    <includeTestResources>false</includeTestResources>
-                    <suppressionsLocation>
-                        gradoop/checkstyle-suppressions.xml
-                    </suppressionsLocation>
-                    <suppressionsFileExpression>
-                        checkstyle.suppressions.file
-                    </suppressionsFileExpression>
-                    <failsOnError>true</failsOnError>
-                    <consoleOutput>true</consoleOutput>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${plugin.maven-findbugs.version}</version>
-                <configuration>
-                    <xmlOutput>true</xmlOutput>
-                    <findbugsXmlOutput>false</findbugsXmlOutput>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -158,6 +112,7 @@
                         <exclude>**/README</exclude>
                         <exclude>**/LICENSE</exclude>
                         <exclude>**/checkstyle.xml</exclude>
+                        <exclude>**/maven.yml</exclude>
                         <exclude>**/pom.xml</exclude>
                         <exclude>src/test/resources/**</exclude>
                         <exclude>src/main/resources/**</exclude>
@@ -198,11 +153,7 @@
             <version>${dep.gradoop.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.gradoop</groupId>
-            <artifactId>gradoop-examples</artifactId>
-            <version>${dep.gradoop.version}</version>
-        </dependency>
+
 
         <!-- Additional dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,40 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${plugin.maven-checkstyle.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.gradoop</groupId>
+                        <artifactId>gradoop-checkstyle</artifactId>
+                        <version>${dep.gradoop.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>gradoop/checkstyle.xml</configLocation>
+                    <headerLocation>gradoop/LICENSE.txt</headerLocation>
+                    <includeResources>false</includeResources>
+                    <includeTestResources>false</includeTestResources>
+                    <suppressionsLocation>
+                        gradoop/checkstyle-suppressions.xml
+                    </suppressionsLocation>
+                    <suppressionsFileExpression>
+                        checkstyle.suppressions.file
+                    </suppressionsFileExpression>
+                    <failsOnError>true</failsOnError>
+                    <consoleOutput>true</consoleOutput>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${plugin.maven-jar.version}</version>
                 <executions>

--- a/src/main/java/org/gradoop/examples/AbstractRunner.java
+++ b/src/main/java/org/gradoop/examples/AbstractRunner.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradoop.examples;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.gradoop.flink.io.api.DataSink;
+import org.gradoop.flink.io.api.DataSource;
+import org.gradoop.flink.io.impl.csv.CSVDataSink;
+import org.gradoop.flink.io.impl.csv.CSVDataSource;
+import org.gradoop.flink.io.impl.csv.indexed.IndexedCSVDataSink;
+import org.gradoop.flink.io.impl.csv.indexed.IndexedCSVDataSource;
+import org.gradoop.flink.model.impl.epgm.LogicalGraph;
+import org.gradoop.flink.util.GradoopFlinkConfig;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Base class for the SyntheticDataGenerator
+ */
+public abstract class AbstractRunner {
+  /**
+   * Command line options for the runner.
+   */
+  protected static final Options OPTIONS = new Options();
+  /**
+   * Graph format used as default
+   */
+  protected static final String DEFAULT_FORMAT = "csv";
+  /**
+   * Flink execution environment.
+   */
+  private static ExecutionEnvironment ENV;
+
+  /**
+   * Parses the program arguments and performs sanity checks.
+   *
+   * @param args program arguments
+   * @param className executing class name (for help display)
+   * @return command line which can be used in the program
+   * @throws ParseException on failure
+   */
+  protected static CommandLine parseArguments(String[] args, String className)
+    throws ParseException {
+    if (args.length == 0) {
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp(className, OPTIONS, true);
+      return null;
+    }
+    return new DefaultParser().parse(OPTIONS, args);
+  }
+
+  /**
+   * Reads an EPGM database from a given directory  using a {@link CSVDataSource}.
+   *
+   * @param directory path to EPGM database
+   * @return EPGM logical graph
+   * @throws IOException on failure
+   */
+  protected static LogicalGraph readLogicalGraph(String directory) throws IOException {
+    return readLogicalGraph(directory, DEFAULT_FORMAT);
+  }
+
+  /**
+   * Reads an EPGM database from a given directory.
+   *
+   * @param directory path to EPGM database
+   * @param format format in which the graph is stored (csv, indexed)
+   * @return EPGM logical graph
+   * @throws IOException on failure
+   */
+  protected static LogicalGraph readLogicalGraph(String directory, String format)
+    throws IOException {
+    return getDataSource(directory, format).getLogicalGraph();
+  }
+
+  /**
+   * Writes a logical graph into the specified directory using a {@link CSVDataSink}.
+   *
+   * @param graph logical graph
+   * @param directory output path
+   * @throws Exception on failure
+   */
+  protected static void writeLogicalGraph(LogicalGraph graph, String directory) throws Exception {
+    writeLogicalGraph(graph, directory, DEFAULT_FORMAT);
+  }
+
+  /**
+   * Writes a logical graph into a given directory.
+   *
+   * @param graph logical graph
+   * @param directory output path
+   * @param format output format (csv, indexed)
+   * @throws Exception on failure
+   */
+  protected static void writeLogicalGraph(LogicalGraph graph, String directory, String format)
+    throws Exception {
+    graph.writeTo(getDataSink(directory, format, graph.getConfig()), true);
+    getExecutionEnvironment().execute();
+  }
+
+  /**
+   * Returns a Flink execution environment.
+   *
+   * @return Flink execution environment
+   */
+  protected static ExecutionEnvironment getExecutionEnvironment() {
+    if (ENV == null) {
+      ENV = ExecutionEnvironment.getExecutionEnvironment();
+    }
+    return ENV;
+  }
+
+  /**
+   * Appends a file separator to the given directory (if not already existing).
+   *
+   * @param directory directory
+   * @return directory with OS specific file separator
+   */
+  private static String appendSeparator(final String directory) {
+    final String fileSeparator = System.getProperty("file.separator");
+    String result = directory;
+    if (!directory.endsWith(fileSeparator)) {
+      result = directory + fileSeparator;
+    }
+    return result;
+  }
+
+  /**
+   * Converts the given DOT file into a PNG image. Note that this method requires the "dot" command
+   * to be available locally.
+   *
+   * @param dotFile path to DOT file
+   * @param pngFile path to PNG file
+   * @throws IOException on failure
+   */
+  protected static void convertDotToPNG(String dotFile, String pngFile) throws IOException {
+    ProcessBuilder pb = new ProcessBuilder("dot", "-Tpng", dotFile);
+    File output = new File(pngFile);
+    pb.redirectOutput(ProcessBuilder.Redirect.appendTo(output));
+    pb.start();
+  }
+
+  /**
+   * Returns an EPGM DataSource for a given directory and format.
+   *
+   * @param directory input path
+   * @param format format in which the data is stored (csv, indexed, json)
+   * @return DataSource for EPGM Data
+   */
+  private static DataSource getDataSource(String directory, String format) {
+    directory = appendSeparator(directory);
+    GradoopFlinkConfig config = GradoopFlinkConfig.createConfig(getExecutionEnvironment());
+    format = format.toLowerCase();
+
+    switch (format) {
+    case "csv":
+      return new CSVDataSource(directory, config);
+    case "indexed":
+      return new IndexedCSVDataSource(directory, config);
+    default:
+      throw new IllegalArgumentException("Unsupported format: " + format);
+    }
+  }
+
+  /**
+   * Returns an EPGM DataSink for a given directory and format.
+   *
+   * @param directory output path
+   * @param format output format (csv, indexed, json)
+   * @param config gradoop config
+   * @return DataSink for EPGM Data
+   */
+  private static DataSink getDataSink(String directory, String format, GradoopFlinkConfig config) {
+    directory = appendSeparator(directory);
+    format = format.toLowerCase();
+
+    switch (format) {
+    case "csv":
+      return new CSVDataSink(directory, config);
+    case "indexed":
+      return new IndexedCSVDataSink(directory, config);
+    default:
+      throw new IllegalArgumentException("Unsupported format: " + format);
+    }
+  }
+}

--- a/src/main/java/org/gradoop/examples/dimspan/SyntheticDataGenerator.java
+++ b/src/main/java/org/gradoop/examples/dimspan/SyntheticDataGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/examples/dimspan/SyntheticDataGenerator.java
+++ b/src/main/java/org/gradoop/examples/dimspan/SyntheticDataGenerator.java
@@ -53,7 +53,7 @@ public class SyntheticDataGenerator
    * Main program to run the example. Arguments are the available options.
    *
    * @param args program arguments
-   * @throws Exception
+   * @throws Exception on failure
    */
   @SuppressWarnings("unchecked")
   public static void main(String[] args) throws Exception {

--- a/src/main/java/org/gradoop/examples/dimspan/package-info.java
+++ b/src/main/java/org/gradoop/examples/dimspan/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/examples/package-info.java
+++ b/src/main/java/org/gradoop/examples/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * AbstractRunner class taken from the Gradoop-Benchmark repository
+ */
+package org.gradoop.examples;

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/FoodBroker.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/FoodBroker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.gradoop.flink.datagen.transactions.foodbroker;
 
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.functions.EnsureGraphContainment;
@@ -28,8 +28,8 @@ import org.gradoop.flink.datagen.transactions.foodbroker.generators.EmployeeGene
 import org.gradoop.flink.datagen.transactions.foodbroker.generators.LogisticsGenerator;
 import org.gradoop.flink.datagen.transactions.foodbroker.generators.ProductGenerator;
 import org.gradoop.flink.datagen.transactions.foodbroker.generators.VendorGenerator;
-import org.gradoop.flink.model.api.epgm.GraphCollection;
-import org.gradoop.flink.model.api.epgm.GraphCollectionFactory;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
+import org.gradoop.flink.model.impl.epgm.GraphCollectionFactory;
 import org.gradoop.flink.model.api.operators.GraphCollectionGenerator;
 import org.gradoop.flink.model.impl.layouts.transactional.TxCollectionLayoutFactory;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
@@ -55,23 +55,23 @@ public class FoodBroker implements GraphCollectionGenerator {
   /**
    * Set which contains all customer vertices.
    */
-  private DataSet<Vertex> customers;
+  private DataSet<EPGMVertex> customers;
   /**
    * Set which contains all vendor vertices.
    */
-  private DataSet<Vertex> vendors;
+  private DataSet<EPGMVertex> vendors;
   /**
    * Set which contains all logistic vertices.
    */
-  private DataSet<Vertex> logistics;
+  private DataSet<EPGMVertex> logistics;
   /**
    * Set which contains all employee vertices.
    */
-  private DataSet<Vertex> employees;
+  private DataSet<EPGMVertex> employees;
   /**
    * Set which contains all product vertices.
    */
-  private DataSet<Vertex> products;
+  private DataSet<EPGMVertex> products;
 
   /**
    * Valued constructor.
@@ -101,8 +101,9 @@ public class FoodBroker implements GraphCollectionGenerator {
       .getCaseCount());
 
     DataSet<GraphTransaction> cases = caseSeeds
-      .map(new Brokerage(gradoopFlinkConfig.getGraphHeadFactory(), gradoopFlinkConfig
-        .getVertexFactory(), gradoopFlinkConfig.getEdgeFactory(), foodBrokerConfig))
+      .map(new Brokerage(gradoopFlinkConfig.getGraphCollectionFactory().getGraphHeadFactory(),
+        gradoopFlinkConfig.getGraphCollectionFactory().getVertexFactory(),
+        gradoopFlinkConfig.getGraphCollectionFactory().getEdgeFactory(), foodBrokerConfig))
       .withBroadcastSet(customers, FoodBrokerBroadcastNames.BC_CUSTOMERS)
       .withBroadcastSet(vendors, FoodBrokerBroadcastNames.BC_VENDORS)
       .withBroadcastSet(logistics, FoodBrokerBroadcastNames.BC_LOGISTICS)
@@ -113,9 +114,9 @@ public class FoodBroker implements GraphCollectionGenerator {
     // Phase 2.2: Run Complaint Handling
     cases = cases
       .map(new ComplaintHandling(
-        gradoopFlinkConfig.getGraphHeadFactory(),
-        gradoopFlinkConfig.getVertexFactory(),
-        gradoopFlinkConfig.getEdgeFactory(), foodBrokerConfig))
+        gradoopFlinkConfig.getGraphCollectionFactory().getGraphHeadFactory(),
+        gradoopFlinkConfig.getGraphCollectionFactory().getVertexFactory(),
+        gradoopFlinkConfig.getGraphCollectionFactory().getEdgeFactory(), foodBrokerConfig))
       .withBroadcastSet(customers, FoodBrokerBroadcastNames.BC_CUSTOMERS)
       .withBroadcastSet(vendors, FoodBrokerBroadcastNames.BC_VENDORS)
       .withBroadcastSet(logistics, FoodBrokerBroadcastNames.BC_LOGISTICS)
@@ -144,5 +145,4 @@ public class FoodBroker implements GraphCollectionGenerator {
     employees = new EmployeeGenerator(gradoopFlinkConfig, foodBrokerConfig).generate();
     products = new ProductGenerator(gradoopFlinkConfig, foodBrokerConfig).generate();
   }
-
 }

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerAcronyms.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerAcronyms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerBroadcastNames.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerBroadcastNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerConfig.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerConfig.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerConfig.java
@@ -49,6 +49,7 @@ public class FoodBrokerConfig implements Serializable {
    * Valued constructor.
    *
    * @param configString string representing a json object
+   * @throws JSONException on failure
    */
   public FoodBrokerConfig(String configString) throws JSONException {
     root = new JSONObject(configString);
@@ -59,8 +60,8 @@ public class FoodBrokerConfig implements Serializable {
    *
    * @param configPath path to the config file
    * @return new FoodBrokerConfig
-   * @throws IOException
-   * @throws JSONException
+   * @throws IOException on failure
+   * @throws JSONException on failure
    */
   public static FoodBrokerConfig fromFile(String configPath)
     throws IOException, JSONException {
@@ -73,7 +74,7 @@ public class FoodBrokerConfig implements Serializable {
    *
    * @param configString string representing a json object
    * @return new FoodBrokerConfig
-   * @throws JSONException
+   * @throws JSONException on failure
    */
   public static FoodBrokerConfig fromJSONString(String configString)
     throws JSONException {
@@ -102,7 +103,7 @@ public class FoodBrokerConfig implements Serializable {
    *
    * @param className class name of the master data
    * @return json object of the searched master data
-   * @throws JSONException
+   * @throws JSONException on failure
    */
   private JSONObject getMasterDataConfigNode(String className) throws JSONException {
     return root.getJSONObject("MasterData").getJSONObject(className);
@@ -112,7 +113,7 @@ public class FoodBrokerConfig implements Serializable {
    * Loads the number of companies to use.
    *
    * @return number of companies to use
-   * @throws JSONException
+   * @throws JSONException on failure
    */
   public int getCompanyCount() throws JSONException {
     return getMasterDataConfigNode("Company").getInt("companyCount");
@@ -122,7 +123,7 @@ public class FoodBrokerConfig implements Serializable {
    * Loads the number of holdings to use.
    *
    * @return number of holdings to use
-   * @throws JSONException
+   * @throws JSONException on failure
    */
   public int getHoldingCount() throws JSONException {
     return getMasterDataConfigNode("Company").getInt("holdingCount");
@@ -132,7 +133,7 @@ public class FoodBrokerConfig implements Serializable {
    * Loads the min number of branches for a company.
    *
    * @return min number of branches for a company
-   * @throws JSONException
+   * @throws JSONException on failure
    */
   public int getBranchMinAmount() throws JSONException {
     return getMasterDataConfigNode("Company").getInt("branchesMin");
@@ -142,7 +143,7 @@ public class FoodBrokerConfig implements Serializable {
    * Loads the max number of branches for a company.
    *
    * @return max number of branches for a company
-   * @throws JSONException
+   * @throws JSONException on failure
    */
   public int getBranchMaxAmount() throws JSONException {
     return getMasterDataConfigNode("Company").getInt("branchesMax");
@@ -436,7 +437,7 @@ public class FoodBrokerConfig implements Serializable {
    * Loads the "TransactionalData" object.
    *
    * @return json object of the transactional data nodes
-   * @throws JSONException
+   * @throws JSONException on failure
    */
   private JSONObject getTransactionalNodes() throws JSONException {
     return root.getJSONObject("TransactionalData");
@@ -446,7 +447,7 @@ public class FoodBrokerConfig implements Serializable {
    * Loads the "Quality" object.
    *
    * @return json object containing the quality settings
-   * @throws JSONException
+   * @throws JSONException on failure
    */
   private JSONObject getQualityNode() throws JSONException {
     return root.getJSONObject("Quality");

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerConfigurationKeys.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerConfigurationKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerConstants.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerEdgeLabels.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerEdgeLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerPropertyKeys.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerPropertyKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerPropertyValues.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerPropertyValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerVertexLabels.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/FoodBrokerVertexLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/package-info.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/config/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/EnsureGraphContainment.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/EnsureGraphContainment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 
 /**
@@ -29,7 +29,7 @@ public class EnsureGraphContainment implements MapFunction<GraphTransaction, Gra
   public GraphTransaction map(GraphTransaction graph) throws Exception {
     GradoopIdSet graphIds = GradoopIdSet.fromExisting(graph.getGraphHead().getId());
 
-    for (Vertex vertex : graph.getVertices()) {
+    for (EPGMVertex vertex : graph.getVertices()) {
       vertex.setGraphIds(graphIds);
     }
     return graph;

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/TargetGraphIdList.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/TargetGraphIdList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/TargetGraphIdPair.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/TargetGraphIdPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,15 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.Edge;
+import org.gradoop.common.model.impl.pojo.EPGMEdge;
 
 /**
  * Creates tuples containing the target id of an edge together with the edges graph id.
  */
-public class TargetGraphIdPair implements MapFunction<Edge, Tuple2<GradoopId, GradoopId>> {
+public class TargetGraphIdPair implements MapFunction<EPGMEdge, Tuple2<GradoopId, GradoopId>> {
 
   @Override
-  public Tuple2<GradoopId, GradoopId> map(Edge edge) throws Exception {
+  public Tuple2<GradoopId, GradoopId> map(EPGMEdge edge) throws Exception {
     return new Tuple2<>(edge.getTargetId(), edge.getGraphIds().iterator().next());
   }
 }

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/UpdateGraphIds.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/UpdateGraphIds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,17 @@ import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
 import org.gradoop.common.model.impl.id.GradoopIdSet;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 
 /**
  * Updates the graph id list of a vertex to the one of the tuple's second element. The first
  * element is the gradoop id of the vertex.
  */
 public class UpdateGraphIds
-  implements JoinFunction<Tuple2<GradoopId, GradoopIdSet>, Vertex, Vertex> {
+  implements JoinFunction<Tuple2<GradoopId, GradoopIdSet>, EPGMVertex, EPGMVertex> {
 
   @Override
-  public Vertex join(Tuple2<GradoopId, GradoopIdSet> pair, Vertex vertex) throws Exception {
+  public EPGMVertex join(Tuple2<GradoopId, GradoopIdSet> pair, EPGMVertex vertex) throws Exception {
     vertex.setGraphIds(pair.f1);
     return vertex;
   }

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/BusinessRelation.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/BusinessRelation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerPropertyKeys;
@@ -42,14 +42,12 @@ public abstract class BusinessRelation extends Person {
 
   /**
    * Valued constructor.
-   *
-   * @param vertexFactory    EPGM vertex factory
+   *  @param epgmVertexFactory    EPGM vertex factory
    * @param foodBrokerConfig FoodBroker configuration
    */
-  public BusinessRelation(VertexFactory vertexFactory, FoodBrokerConfig foodBrokerConfig) {
-    super(vertexFactory, foodBrokerConfig);
+  public BusinessRelation(VertexFactory<EPGMVertex> epgmVertexFactory, FoodBrokerConfig foodBrokerConfig) {
+    super(epgmVertexFactory, foodBrokerConfig);
   }
-
 
   @Override
   public void open(Configuration parameters) throws Exception {
@@ -60,8 +58,8 @@ public abstract class BusinessRelation extends Person {
   }
 
   @Override
-  public Vertex map(MasterDataSeed seed) throws  Exception {
-    Vertex vertex = super.map(seed);
+  public EPGMVertex map(MasterDataSeed seed) throws  Exception {
+    EPGMVertex vertex = super.map(seed);
 
     // set rnd company
     Random rand = new Random();

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/BusinessRelationDataMapper.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/BusinessRelationDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerPropertyKeys;
 import org.gradoop.flink.datagen.transactions.foodbroker.tuples.BusinessRelationData;
 
@@ -27,7 +27,7 @@ import org.gradoop.flink.datagen.transactions.foodbroker.tuples.BusinessRelation
  * business relation data.
  */
 public class BusinessRelationDataMapper
-  implements MapFunction<Vertex, Tuple2<GradoopId, BusinessRelationData>> {
+  implements MapFunction<EPGMVertex, Tuple2<GradoopId, BusinessRelationData>> {
 
   /**
    * Reduce object instantiation.
@@ -45,7 +45,7 @@ public class BusinessRelationDataMapper
    * {@inheritDoc}
    */
   @Override
-  public Tuple2<GradoopId, BusinessRelationData> map(Vertex v) throws Exception {
+  public Tuple2<GradoopId, BusinessRelationData> map(EPGMVertex v) throws Exception {
     reuseBusinessRelationData
       .setQuality(v.getPropertyValue(FoodBrokerPropertyKeys.QUALITY_KEY).getFloat());
     reuseBusinessRelationData

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Customer.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Customer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerAcronyms;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
@@ -51,12 +51,11 @@ public class Customer extends BusinessRelation {
 
   /**
    * Valued constructor.
-   *
-   * @param vertexFactory EPGM vertex factory
+   *  @param epgmVertexFactory EPGM vertex factory
    * @param foodBrokerConfig FoodBroker configuration.
    */
-  public Customer(VertexFactory vertexFactory, FoodBrokerConfig foodBrokerConfig) {
-    super(vertexFactory, foodBrokerConfig);
+  public Customer(VertexFactory<EPGMVertex> epgmVertexFactory, FoodBrokerConfig foodBrokerConfig) {
+    super(epgmVertexFactory, foodBrokerConfig);
   }
 
   @Override
@@ -71,10 +70,10 @@ public class Customer extends BusinessRelation {
   }
 
   @Override
-  public Vertex map(MasterDataSeed seed) throws  Exception {
+  public EPGMVertex map(MasterDataSeed seed) throws  Exception {
     //set rnd name
     Random random = new Random();
-    Vertex vertex = super.map(seed);
+    EPGMVertex vertex = super.map(seed);
     vertex.setProperty(
       FoodBrokerPropertyKeys.NAME_KEY, adjectives.get(random.nextInt(adjectiveCount)) + " " +
       nouns.get(random.nextInt(nounCount)));

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Employee.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerAcronyms;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
@@ -60,11 +60,10 @@ public class Employee extends Person {
 
   /**
    * Valued constructor.
-   *
-   * @param vertexFactory EPGM vertex factory.
+   *  @param vertexFactory EPGM vertex factory.
    * @param foodBrokerConfig FoodBroker configuration.
    */
-  public Employee(VertexFactory vertexFactory, FoodBrokerConfig foodBrokerConfig) {
+  public Employee(VertexFactory<EPGMVertex> vertexFactory, FoodBrokerConfig foodBrokerConfig) {
     super(vertexFactory, foodBrokerConfig);
   }
 
@@ -85,8 +84,8 @@ public class Employee extends Person {
   }
 
   @Override
-  public Vertex map(MasterDataSeed seed) throws  Exception {
-    Vertex vertex = super.map(seed);
+  public EPGMVertex map(MasterDataSeed seed) throws  Exception {
+    EPGMVertex vertex = super.map(seed);
     Random random = new Random();
     //set rnd name and gender
     String gender;

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/EmployeeDataMapper.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/EmployeeDataMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerPropertyKeys;
 import org.gradoop.flink.datagen.transactions.foodbroker.tuples.EmployeeData;
 
@@ -26,7 +26,7 @@ import org.gradoop.flink.datagen.transactions.foodbroker.tuples.EmployeeData;
  * Creates a tuple from the given vertex. The tuple consists of the gradoop id and the relevant
  * person data.
  */
-public class EmployeeDataMapper implements MapFunction<Vertex, Tuple2<GradoopId, EmployeeData>> {
+public class EmployeeDataMapper implements MapFunction<EPGMVertex, Tuple2<GradoopId, EmployeeData>> {
 
   /**
    * Reduce object instantiation.
@@ -44,7 +44,7 @@ public class EmployeeDataMapper implements MapFunction<Vertex, Tuple2<GradoopId,
    * {@inheritDoc}
    */
   @Override
-  public Tuple2<GradoopId, EmployeeData> map(Vertex v) throws Exception {
+  public Tuple2<GradoopId, EmployeeData> map(EPGMVertex v) throws Exception {
     reuseEmployeeData.setQuality(v.getPropertyValue(FoodBrokerPropertyKeys.QUALITY_KEY).getFloat());
     reuseEmployeeData.setCity(v.getPropertyValue(FoodBrokerPropertyKeys.CITY_KEY).getString());
     return new Tuple2<>(v.getId(), reuseEmployeeData);

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Logistics.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Logistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerAcronyms;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
@@ -59,14 +59,14 @@ public class Logistics extends MasterData {
   /**
    * EPGM vertex factory.
    */
-  private final VertexFactory vertexFactory;
+  private final VertexFactory<EPGMVertex> vertexFactory;
 
   /**
    * Valued constructor.
    *
    * @param vertexFactory EPGM vertex factory
    */
-  public Logistics(VertexFactory vertexFactory) {
+  public Logistics(VertexFactory<EPGMVertex> vertexFactory) {
     this.vertexFactory = vertexFactory;
   }
 
@@ -85,7 +85,7 @@ public class Logistics extends MasterData {
   }
 
   @Override
-  public Vertex map(MasterDataSeed seed) throws  Exception {
+  public EPGMVertex map(MasterDataSeed seed) throws  Exception {
     //create standard properties from acronym and seed
     Properties properties = createDefaultProperties(seed, getAcronym());
     Random random = new Random();

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/MasterData.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/MasterData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerAcronyms;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerPropertyKeys;
@@ -26,7 +26,7 @@ import org.gradoop.flink.datagen.transactions.foodbroker.tuples.MasterDataSeed;
 /**
  * Provides default properties and a business identifier for master data objects.
  */
-public abstract class MasterData extends RichMapFunction<MasterDataSeed, Vertex> {
+public abstract class MasterData extends RichMapFunction<MasterDataSeed, EPGMVertex> {
   /**
    * Creates a business identifier.
    *

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/MasterDataMapFromTuple.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/MasterDataMapFromTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/MasterDataQualityMapper.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/MasterDataQualityMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,17 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerPropertyKeys;
 
 /**
  * Creates a master data tuple from the given vertex. The tuple consists of the gradoop id and
  * the quality.
  */
-public class MasterDataQualityMapper implements MapFunction<Vertex, Tuple2<GradoopId, Float>> {
+public class MasterDataQualityMapper implements MapFunction<EPGMVertex, Tuple2<GradoopId, Float>> {
 
   @Override
-  public Tuple2<GradoopId, Float> map(Vertex v) throws Exception {
+  public Tuple2<GradoopId, Float> map(EPGMVertex v) throws Exception {
     return new Tuple2<>(v.getId(), v.getPropertyValue(
       FoodBrokerPropertyKeys.QUALITY_KEY).getFloat());
   }

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Person.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
@@ -36,13 +36,13 @@ public abstract class Person extends MasterData {
    */
   private List<String> cities;
   /**
-   * Amount of pissible cities.
+   * Amount of possible cities.
    */
   private Integer cityCount;
   /**
    * EPGM vertex factory.
    */
-  private final VertexFactory vertexFactory;
+  private final VertexFactory<EPGMVertex> vertexFactory;
   /**
    * FoodBroker configuration.
    */
@@ -50,11 +50,10 @@ public abstract class Person extends MasterData {
 
   /**
    * Valued constructor.
-   *
-   * @param vertexFactory EPGM vertex factory
+   *  @param vertexFactory EPGM vertex factory
    * @param foodBrokerConfig FoodBroker configuration
    */
-  public Person(VertexFactory vertexFactory, FoodBrokerConfig foodBrokerConfig) {
+  public Person(VertexFactory<EPGMVertex> vertexFactory, FoodBrokerConfig foodBrokerConfig) {
     this.vertexFactory = vertexFactory;
     this.foodBrokerConfig = foodBrokerConfig;
   }
@@ -69,7 +68,7 @@ public abstract class Person extends MasterData {
   }
 
   @Override
-  public Vertex map(MasterDataSeed seed) throws  Exception {
+  public EPGMVertex map(MasterDataSeed seed) throws  Exception {
     //create standard properties from acronym and seed
     Properties properties = createDefaultProperties(seed, getAcronym());
     Random random = new Random();

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Product.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.properties.Properties;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerAcronyms;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
@@ -109,13 +109,13 @@ public class Product extends MasterData {
    */
   private Integer nameGroupPairCount;
   /**
-   * Amount odf possible adjectives.
+   * Amount of possible adjectives.
    */
   private Integer adjectiveCount;
   /**
-   * EPGM vertex facoty.
+   * EPGM vertex factory.
    */
-  private final VertexFactory vertexFactory;
+  private final VertexFactory<EPGMVertex> vertexFactory;
   /**
    * FoodBroker configuration.
    */
@@ -123,11 +123,10 @@ public class Product extends MasterData {
 
   /**
    * Valued constructor.
-   *
-   * @param vertexFactory EPGM vertex factory
+   *  @param vertexFactory EPGM vertex factory
    * @param config FoodBroker configuration
    */
-  public Product(VertexFactory vertexFactory, FoodBrokerConfig config) {
+  public Product(VertexFactory<EPGMVertex> vertexFactory, FoodBrokerConfig config) {
     this.vertexFactory = vertexFactory;
     this.config = config;
   }
@@ -146,7 +145,7 @@ public class Product extends MasterData {
   }
 
   @Override
-  public Vertex map(MasterDataSeed seed) throws  Exception {
+  public EPGMVertex map(MasterDataSeed seed) throws  Exception {
     //create standard properties from acronym and seed
     Properties properties = createDefaultProperties(seed, FoodBrokerAcronyms.PRODUCT_ACRONYM);
     Random random = new Random();

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/ProductPriceMapper.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/ProductPriceMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerPropertyKeys;
 
 import java.math.BigDecimal;
@@ -28,10 +28,10 @@ import java.math.BigDecimal;
  * the price.
  */
 public class ProductPriceMapper implements
-  MapFunction<Vertex, Tuple2<GradoopId, BigDecimal>> {
+  MapFunction<EPGMVertex, Tuple2<GradoopId, BigDecimal>> {
 
   @Override
-  public Tuple2<GradoopId, BigDecimal> map(Vertex v) throws Exception {
+  public Tuple2<GradoopId, BigDecimal> map(EPGMVertex v) throws Exception {
     BigDecimal price = v.getPropertyValue(FoodBrokerPropertyKeys.PRICE_KEY).getBigDecimal();
     return new Tuple2<>(v.getId(), price);
   }

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/UserClients.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/UserClients.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,19 +17,19 @@ package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.util.Collector;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 
 import java.util.Set;
 
 /**
  * Collects all users and clients given by sets into one dataset.
  */
-public class UserClients implements FlatMapFunction<Set<Vertex>, Vertex> {
+public class UserClients implements FlatMapFunction<Set<EPGMVertex>, EPGMVertex> {
 
   @Override
-  public void flatMap(Set<Vertex> vertices,
-    Collector<Vertex> collector) throws Exception {
-    for (Vertex vertex : vertices) {
+  public void flatMap(Set<EPGMVertex> vertices,
+    Collector<EPGMVertex> collector) throws Exception {
+    for (EPGMVertex vertex : vertices) {
       collector.collect(vertex);
     }
   }

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Vendor.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/Vendor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.functions.masterdata;
 
 import org.apache.flink.configuration.Configuration;
-import org.gradoop.common.model.impl.pojo.Vertex;
-import org.gradoop.common.model.impl.pojo.VertexFactory;
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerAcronyms;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
@@ -51,11 +51,10 @@ public class Vendor extends BusinessRelation {
 
   /**
    * Valued constructor.
-   *
-   * @param vertexFactory EPGM vertex factory
+   *  @param vertexFactory EPGM vertex factory
    * @param foodBrokerConfig FoodBroker configuration
    */
-  public Vendor(VertexFactory vertexFactory, FoodBrokerConfig foodBrokerConfig) {
+  public Vendor(VertexFactory<EPGMVertex> vertexFactory, FoodBrokerConfig foodBrokerConfig) {
     super(vertexFactory, foodBrokerConfig);
   }
 
@@ -71,10 +70,10 @@ public class Vendor extends BusinessRelation {
   }
 
   @Override
-  public Vertex map(MasterDataSeed seed) throws  Exception {
+  public EPGMVertex map(MasterDataSeed seed) throws  Exception {
     //set rnd name
     Random random = new Random();
-    Vertex vertex = super.map(seed);
+    EPGMVertex vertex = super.map(seed);
     vertex.setProperty(
       FoodBrokerPropertyKeys.NAME_KEY, adjectives.get(random.nextInt(adjectiveCount)) + " " +
       nouns.get(random.nextInt(nounCount)));

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/package-info.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/masterdata/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/package-info.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/ComplaintHandling.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/ComplaintHandling.java
@@ -217,7 +217,8 @@ public class ComplaintHandling extends AbstractProcess
     // sales orders, which are late
     for (EPGMVertex deliveryNote : deliveryNotes) {
       if (deliveryNote.getPropertyValue(FoodBrokerPropertyKeys.DATE_KEY).getDate().getLong(ChronoField.ERA) >
-        salesOrder.getPropertyValue(FoodBrokerPropertyKeys.DELIVERYDATE_KEY).getDate().getLong(ChronoField.ERA)) {
+        salesOrder.getPropertyValue(FoodBrokerPropertyKeys.DELIVERYDATE_KEY).getDate()
+          .getLong(ChronoField.ERA)) {
         lateSalesOrderLines.addAll(salesOrderLines);
       }
     }
@@ -231,7 +232,8 @@ public class ComplaintHandling extends AbstractProcess
       }
       Calendar calendar = Calendar.getInstance();
       calendar.setTimeInMillis(
-        salesOrder.getPropertyValue(FoodBrokerPropertyKeys.DELIVERYDATE_KEY).getDate().getLong(ChronoField.ERA));
+        salesOrder.getPropertyValue(FoodBrokerPropertyKeys.DELIVERYDATE_KEY).getDate()
+          .getLong(ChronoField.ERA));
       calendar.add(Calendar.DATE, 1);
       long createdDate = calendar.getTimeInMillis();
 

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/ComplaintHandling.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/ComplaintHandling.java
@@ -191,7 +191,6 @@ public class ComplaintHandling extends AbstractProcess
         for (EPGMEdge purchOrderLine : currentPurchOrderLines) {
           badSalesOrderLines.add(getCorrespondingSalesOrderLine(purchOrderLine.getId()));
         }
-        //serafin Chrono Field??
         EPGMVertex ticket = newTicket(
           FoodBrokerPropertyValues.BADQUALITY_TICKET_PROBLEM,
           deliveryNote.getPropertyValue(FoodBrokerPropertyKeys.DATE_KEY).getDate().getLong(ChronoField.ERA),
@@ -216,7 +215,6 @@ public class ComplaintHandling extends AbstractProcess
 
     // Iterate over all delivery notes and take the sales order lines of
     // sales orders, which are late
-    //Serafin Chrono.field??
     for (EPGMVertex deliveryNote : deliveryNotes) {
       if (deliveryNote.getPropertyValue(FoodBrokerPropertyKeys.DATE_KEY).getDate().getLong(ChronoField.ERA) >
         salesOrder.getPropertyValue(FoodBrokerPropertyKeys.DELIVERYDATE_KEY).getDate().getLong(ChronoField.ERA)) {

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/package-info.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/functions/process/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/AbstractMasterDataGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/AbstractMasterDataGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.generators;
 
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.gradoop.common.model.impl.pojo.VertexFactory;
+
+import org.gradoop.common.model.api.entities.VertexFactory;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.tuples.MasterDataSeed;
 import org.gradoop.flink.util.GradoopFlinkConfig;
@@ -42,7 +44,7 @@ public abstract class AbstractMasterDataGenerator
   /**
    * EPGM vertex factory.
    */
-  protected final VertexFactory vertexFactory;
+  protected final VertexFactory<EPGMVertex> vertexFactory;
 
   /**
    * Valued constructor.
@@ -54,7 +56,7 @@ public abstract class AbstractMasterDataGenerator
     GradoopFlinkConfig gradoopFlinkConfig, FoodBrokerConfig foodBrokerConfig) {
     this.foodBrokerConfig = foodBrokerConfig;
     this.env = gradoopFlinkConfig.getExecutionEnvironment();
-    this.vertexFactory = gradoopFlinkConfig.getVertexFactory();
+    this.vertexFactory = gradoopFlinkConfig.getLogicalGraphFactory().getVertexFactory();
   }
 
   /**

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/BusinessRelationGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/BusinessRelationGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/CustomerGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/CustomerGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.generators;
 
 import org.apache.flink.api.java.DataSet;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerVertexLabels;
@@ -43,7 +43,7 @@ public class CustomerGenerator extends BusinessRelationGenerator {
   }
 
   @Override
-  public DataSet<Vertex> generate() {
+  public DataSet<EPGMVertex> generate() {
     List<MasterDataSeed> seeds = getMasterDataSeeds(FoodBrokerVertexLabels.CUSTOMER_VERTEX_LABEL);
     loadData();
     return env.fromCollection(seeds)

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/EmployeeGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/EmployeeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.generators;
 
 import org.apache.flink.api.java.DataSet;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerVertexLabels;
@@ -44,7 +44,7 @@ public class EmployeeGenerator
   }
 
   @Override
-  public DataSet<Vertex> generate() {
+  public DataSet<EPGMVertex> generate() {
     List<MasterDataSeed> seeds = getMasterDataSeeds(FoodBrokerVertexLabels.EMPLOYEE_VERTEX_LABEL);
     List<String> cities = foodBrokerConfig
       .getStringValuesFromFile("cities");

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/LogisticsGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/LogisticsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.generators;
 
 import org.apache.flink.api.java.DataSet;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerVertexLabels;
@@ -44,7 +44,7 @@ public class LogisticsGenerator
   }
 
   @Override
-  public DataSet<Vertex> generate() {
+  public DataSet<EPGMVertex> generate() {
     List<MasterDataSeed> seeds = getMasterDataSeeds(FoodBrokerVertexLabels.LOGISTICS_VERTEX_LABEL);
     List<String> cities = foodBrokerConfig
       .getStringValuesFromFile("cities");

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/MasterDataGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/MasterDataGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.generators;
 
 import org.apache.flink.api.java.DataSet;
-import org.gradoop.common.model.api.entities.EPGMVertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 
 /**
  * Interface for generators of master data objects.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/ProductGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/ProductGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.gradoop.flink.datagen.transactions.foodbroker.generators;
 
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerPropertyKeys;
@@ -46,7 +46,7 @@ public class ProductGenerator extends AbstractMasterDataGenerator {
   }
 
   @Override
-  public DataSet<Vertex> generate() {
+  public DataSet<EPGMVertex> generate() {
     List<MasterDataSeed> seeds = getMasterDataSeeds(FoodBrokerVertexLabels.PRODUCT_VERTEX_LABEL);
     List<String> adjectives = foodBrokerConfig
       .getStringValuesFromFile("product.adjectives");

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/VendorGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/VendorGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.gradoop.flink.datagen.transactions.foodbroker.generators;
 
 import org.apache.flink.api.java.DataSet;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerBroadcastNames;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerVertexLabels;
@@ -43,7 +43,7 @@ public class VendorGenerator extends BusinessRelationGenerator {
   }
 
   @Override
-  public DataSet<Vertex> generate() {
+  public DataSet<EPGMVertex> generate() {
     List<MasterDataSeed> seeds = getMasterDataSeeds(FoodBrokerVertexLabels.VENDOR_VERTEX_LABEL);
     loadData();
     return env.fromCollection(seeds)

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/package-info.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/generators/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/package-info.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/BusinessRelationData.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/BusinessRelationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/EmployeeData.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/EmployeeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/MasterDataSeed.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/MasterDataSeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/PersonData.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/PersonData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/package-info.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/foodbroker/tuples/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/predictable/PredictableTransactionsGenerator.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/predictable/PredictableTransactionsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradoop/flink/datagen/transactions/predictable/package-info.java
+++ b/src/main/java/org/gradoop/flink/datagen/transactions/predictable/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/gradoop/flink/algorithms/fsm/DIMSpanConfigTest.java
+++ b/src/test/java/org/gradoop/flink/algorithms/fsm/DIMSpanConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.gradoop.flink.algorithms.fsm.dimspan.config.DataflowStep;
 import org.gradoop.flink.algorithms.fsm.dimspan.config.DictionaryType;
 import org.gradoop.flink.datagen.transactions.predictable.PredictableTransactionsGenerator;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
-import org.gradoop.flink.model.api.epgm.GraphCollection;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/org/gradoop/flink/algorithms/fsm/transactional/predgen/PredictableGeneratorDIMSpanTest.java
+++ b/src/test/java/org/gradoop/flink/algorithms/fsm/transactional/predgen/PredictableGeneratorDIMSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/gradoop/flink/algorithms/fsm/transactional/predgen/PredictableGeneratorFSMTestBase.java
+++ b/src/test/java/org/gradoop/flink/algorithms/fsm/transactional/predgen/PredictableGeneratorFSMTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.gradoop.flink.algorithms.fsm.transactional.predgen;
 import org.apache.flink.api.java.DataSet;
 import org.gradoop.flink.datagen.transactions.predictable.PredictableTransactionsGenerator;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
-import org.gradoop.flink.model.api.epgm.GraphCollection;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.api.operators.UnaryCollectionToCollectionOperator;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
 import org.junit.Assert;

--- a/src/test/java/org/gradoop/flink/algorithms/fsm/transactional/predgen/PredictableGeneratorThinkLikeAnEmbeddingTest.java
+++ b/src/test/java/org/gradoop/flink/algorithms/fsm/transactional/predgen/PredictableGeneratorThinkLikeAnEmbeddingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/gradoop/flink/datagen/transactions/foodbroker/FoodBrokerConfigTest.java
+++ b/src/test/java/org/gradoop/flink/datagen/transactions/foodbroker/FoodBrokerConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/gradoop/flink/datagen/transactions/foodbroker/FoodBrokerTest.java
+++ b/src/test/java/org/gradoop/flink/datagen/transactions/foodbroker/FoodBrokerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,14 @@ import com.google.common.collect.Sets;
 import org.apache.flink.api.java.DataSet;
 import org.codehaus.jettison.json.JSONException;
 import org.gradoop.common.model.impl.id.GradoopId;
-import org.gradoop.common.model.impl.pojo.Edge;
-import org.gradoop.common.model.impl.pojo.Vertex;
+import org.gradoop.common.model.impl.pojo.EPGMEdge;
+import org.gradoop.common.model.impl.pojo.EPGMVertex;
 import org.gradoop.common.model.impl.properties.PropertyValue;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerConfig;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerEdgeLabels;
 import org.gradoop.flink.datagen.transactions.foodbroker.config.FoodBrokerVertexLabels;
 import org.gradoop.flink.model.GradoopFlinkTestBase;
-import org.gradoop.flink.model.api.epgm.GraphCollection;
+import org.gradoop.flink.model.impl.epgm.GraphCollection;
 import org.gradoop.flink.model.impl.functions.epgm.ByLabel;
 import org.gradoop.flink.model.impl.functions.epgm.ByProperty;
 import org.gradoop.flink.model.impl.layouts.transactional.tuples.GraphTransaction;
@@ -53,7 +53,7 @@ public class FoodBrokerTest extends GradoopFlinkTestBase {
   @Test
   public void testSalesQuotationLineCount() throws IOException, JSONException {
     generateCollection();
-    DataSet<Vertex> salesQuotationLines = cases.getVertices()
+    DataSet<EPGMVertex> salesQuotationLines = cases.getVertices()
       .filter(new ByLabel<>("SalesQuotationLine"));
     int min = 1;
     int max = 20;
@@ -73,9 +73,9 @@ public class FoodBrokerTest extends GradoopFlinkTestBase {
   @Test
   public void testSalesOrderCount() throws IOException, JSONException {
     generateCollection();
-    DataSet<Vertex> salesQuotations = cases.getVertices()
+    DataSet<EPGMVertex> salesQuotations = cases.getVertices()
       .filter(new ByLabel<>("SalesQuotation"));
-    DataSet<Vertex> salesOrders = cases.getVertices()
+    DataSet<EPGMVertex> salesOrders = cases.getVertices()
       .filter(new ByLabel<>("SalesOrder"));
 
     double actual = 0;
@@ -151,14 +151,14 @@ public class FoodBrokerTest extends GradoopFlinkTestBase {
     for (GraphTransaction graph : result10K) {
       Set<GradoopId> vertexIds = Sets.newHashSetWithExpectedSize(graph.getVertices().size());
 
-      for (Vertex vertex : graph.getVertices()) {
+      for (EPGMVertex vertex : graph.getVertices()) {
         vertexIds.add(vertex.getId());
         assertTrue(vertex.getGraphIds().size() >= 1);
       }
 
       // EDGE CONSISTENCY
 
-      for (Edge edge : graph.getEdges()) {
+      for (EPGMEdge edge : graph.getEdges()) {
         assertTrue("graph does not contain source of " + edge.getLabel(),
           vertexIds.contains(edge.getSourceId()));
 
@@ -178,15 +178,14 @@ public class FoodBrokerTest extends GradoopFlinkTestBase {
     Set<String> foundVertexLabels = Sets.newHashSet();
     Set<String> foundEdgeLabels = Sets.newHashSet();
 
-
     for (int ignored : new int[] {0, 1, 2}) {
       generateCollection();
 
-      for (Vertex vertex : cases.getVertices().collect()) {
+      for (EPGMVertex vertex : cases.getVertices().collect()) {
         foundVertexLabels.add(vertex.getLabel());
       }
 
-      for (Edge edge : cases.getEdges().collect()) {
+      for (EPGMEdge edge : cases.getEdges().collect()) {
         foundEdgeLabels.add(edge.getLabel());
       }
     }
@@ -261,6 +260,4 @@ public class FoodBrokerTest extends GradoopFlinkTestBase {
       cases = foodBroker.execute();
     }
   }
-
-
 }

--- a/src/test/java/org/gradoop/flink/datagen/transactions/predictable/PredictableTransactionTest.java
+++ b/src/test/java/org/gradoop/flink/datagen/transactions/predictable/PredictableTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 - 2018 Leipzig University (Database Research Group)
+ * Copyright © 2014 - 2019 Leipzig University (Database Research Group)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Updated the Gradoop version to 0.5.1 
* Changed all objects of type `Vertex` | `Edge` | `GraphHead` to `EPGMVertex` | `EPGMEdge` | `EPGMGraphHead`
* All objects of type `VertexFactory` belong to `VertexFactory<EPGMVertex>` now (same with `EdgeFactory` and `GraphHeadFactory`)
* all occurence of the GradoopFlinkConfig.getVertexFactory() been changed to `GradoopFlinkConfig.getLogicalGraphFactory().getVertexFactory()` or `GradoopFlinkConfig.getGraphCollectionFactory.getVertexFactory()` (same with`Edges` and `GraphHeads`
* the transformation from objects of type `Date` into type `Long` in the `ComplaintHandling` class in line 196 e.g. is now done via the `PropertyValue.getDate().getLong(ChronoField.ERA)` method call
* The `AbstractRunner` class, super class for the `SyntheticDataGenerator` example is not included in the examples of Gradoop 0.5.1 but in the latest Benchmark version. I don´t wanted to include the Benchmark repo as a dependency so i added the `AbstractRunner` class in the Gradoop-Generator project
* The whole `CategoryCharacteristicsSubgraphTest` is (still?) not working and gets ignored. `HasLabel<>()` is an aggregate function in the new Gradoop version and can´t be used as a filter function anymore
* Changed the copyright of the license headers of each class to 2019
* added a .github.workflows directory for the `maven.yml` file identicall to the build in Gradoop/Gradoop-Capf etc
* someone has to check/update the pom.xml script
